### PR TITLE
Create derived cursor theme with highlighting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,102 +10,113 @@ sb_right_arrow sb_up_arrow sb_v_double_arrow tcross top_left_corner \
 top_right_corner top_side top_tee ul_angle ur_angle vertical-text watch \
 X_cursor xterm zoom-in zoom-out
 
-all: png
-	./genin.py $(SIZES)
+all: png_hl
 	mkdir -p Adwaita/cursors
+	mkdir -p Adwaita-highlight/cursors
 	for c in $(CURSORS); do \
 	  xcursorgen $${c}.in Adwaita/cursors/$${c}; \
+	  xcursorgen $${c}_hl.in Adwaita-highlight/cursors/$${c}; \
 	done
 
 	# Now make cursor aliases.
-	cd Adwaita/cursors;                                                \
-	ln   -sf   bd_double_arrow       c7088f0f3e6c8088236ef8e1e3e70000; \
-	ln   -sf   bd_double_arrow       nwse-resize;                      \
-	ln   -sf   bd_double_arrow       size_fdiag;                       \
-	ln   -sf   bottom_left_corner    sw-resize;                        \
-	ln   -sf   bottom_right_corner   se-resize;                        \
-	ln   -sf   bottom_side           s-resize;                         \
-	ln   -sf   copy                  1081e37283d90000800003c07f3ef6bf; \
-	ln   -sf   copy                  6407b0e94181790501fd1e167b474872; \
-	ln   -sf   cross                 cross_reverse;                    \
-	ln   -sf   cross                 diamond_cross;                    \
-	ln   -sf   crossed_circle        03b6e0fcb3499374a867c041f52298f0; \
-	ln   -sf   crossed_circle        forbidden;                        \
-	ln   -sf   crossed_circle        not-allowed;                      \
-	ln   -sf   dnd-link              alias;                            \
-	ln   -sf   dnd-no-drop           no-drop;                          \
-	ln   -sf   dotbox                dot_box_mask;                     \
-	ln   -sf   dotbox                draped_box;                       \
-	ln   -sf   dotbox                icon;                             \
-	ln   -sf   dotbox                target;                           \
-	ln   -sf   fd_double_arrow       fcf1c3c7cd4491d801f1e1c78f100000; \
-	ln   -sf   fd_double_arrow       nesw-resize;                      \
-	ln   -sf   fd_double_arrow       size_bdiag;                       \
-	ln   -sf   grabbing              closedhand;                       \
-	ln   -sf   all-scroll            fleur;                            \
-	ln   -sf   all-scroll            size_all;                         \
-	ln   -sf   hand1                 grab;                             \
-	ln   -sf   hand2                 9d800788f1b08800ae810202380a0822; \
-	ln   -sf   hand2                 e29285e634086352946a0e7090d73106; \
-	ln   -sf   hand2                 hand;                             \
-	ln   -sf   hand2                 pointer;                          \
-	ln   -sf   hand2                 pointing_hand;                    \
-	ln   -sf   left_ptr              arrow;                            \
-	ln   -sf   left_ptr              default;                          \
-	ln   -sf   left_ptr              openhand;                         \
-	ln   -sf   left_ptr              top_left_arrow;                   \
-	ln   -sf   left_ptr_watch        08e8e1c95fe2fc01f976f1e063a24ccd; \
-	ln   -sf   left_ptr_watch        3ecb610c1bf2410f44200f48c40d3599; \
-	ln   -sf   left_ptr_watch        progress;                         \
-	ln   -sf   left_side             w-resize;                         \
-	ln   -sf   link                  3085a0e285430894940527032f8b26df; \
-	ln   -sf   link                  640fb0e74195791501fd1ed57b41487f; \
-	ln   -sf   move                  4498f0e0c1937ffe01fd06f973665830; \
-	ln   -sf   move                  9081237383d90e509aa00f00170e968f; \
-	ln   -sf   question_arrow        5c6cd98b3f3ebcb1f9c7f1c204630408; \
-	ln   -sf   question_arrow        d9ce0ab605698f320427677b458ad60b; \
-	ln   -sf   question_arrow        help;                             \
-	ln   -sf   question_arrow        left_ptr_help;                    \
-	ln   -sf   question_arrow        whats_this;                       \
-	ln   -sf   right_ptr             draft_large;                      \
-	ln   -sf   right_ptr             draft_small;                      \
-	ln   -sf   right_side            e-resize;                         \
-	ln   -sf   sb_h_double_arrow     028006030e0e7ebffc7f7070c0600140; \
-	ln   -sf   sb_h_double_arrow     14fef782d02440884392942c11205230; \
-	ln   -sf   sb_h_double_arrow     col-resize;                       \
-	ln   -sf   sb_h_double_arrow     ew-resize;                        \
-	ln   -sf   sb_h_double_arrow     h_double_arrow;                   \
-	ln   -sf   sb_h_double_arrow     size_hor;                         \
-	ln   -sf   sb_h_double_arrow     split_h;                          \
-	ln   -sf   sb_up_arrow           up_arrow;                         \
-	ln   -sf   sb_v_double_arrow     00008160000006810000408080010102; \
-	ln   -sf   sb_v_double_arrow     2870a09082c103050810ffdffffe0204; \
-	ln   -sf   sb_v_double_arrow     double_arrow;                     \
-	ln   -sf   sb_v_double_arrow     ns-resize;                        \
-	ln   -sf   sb_v_double_arrow     row-resize;                       \
-	ln   -sf   sb_v_double_arrow     size_ver;                         \
-	ln   -sf   sb_v_double_arrow     split_v;                          \
-	ln   -sf   sb_v_double_arrow     v_double_arrow;                   \
-	ln   -sf   top_left_corner       nw-resize;                        \
-	ln   -sf   top_right_corner      ne-resize;                        \
-	ln   -sf   top_side              n-resize;                         \
-	ln   -sf   watch                 wait;                             \
-	ln   -sf   X_cursor              pirate;                           \
-	ln   -sf   xterm                 ibeam;                            \
-	ln   -sf   xterm                 text
+	for d in Adwaita/cursors Adwaita-highlight/cursors; do \
+	  cd $${d};                                                \
+	  ln   -sf   bd_double_arrow       c7088f0f3e6c8088236ef8e1e3e70000; \
+	  ln   -sf   bd_double_arrow       nwse-resize;                      \
+	  ln   -sf   bd_double_arrow       size_fdiag;                       \
+	  ln   -sf   bottom_left_corner    sw-resize;                        \
+	  ln   -sf   bottom_right_corner   se-resize;                        \
+	  ln   -sf   bottom_side           s-resize;                         \
+	  ln   -sf   copy                  1081e37283d90000800003c07f3ef6bf; \
+	  ln   -sf   copy                  6407b0e94181790501fd1e167b474872; \
+	  ln   -sf   cross                 cross_regverse;                    \
+	  ln   -sf   cross                 diamond_cross;                    \
+	  ln   -sf   crossed_circle        03b6e0fcb3499374a867c041f52298f0; \
+	  ln   -sf   crossed_circle        forbidden;                        \
+	  ln   -sf   crossed_circle        not-allowed;                      \
+	  ln   -sf   dnd-link              alias;                            \
+	  ln   -sf   dnd-no-drop           no-drop;                          \
+	  ln   -sf   dotbox                dot_box_mask;                     \
+	  ln   -sf   dotbox                draped_box;                       \
+	  ln   -sf   dotbox                icon;                             \
+	  ln   -sf   dotbox                target;                           \
+	  ln   -sf   fd_double_arrow       fcf1c3c7cd4491d801f1e1c78f100000; \
+	  ln   -sf   fd_double_arrow       nesw-resize;                      \
+	  ln   -sf   fd_double_arrow       size_bdiag;                       \
+	  ln   -sf   grabbing              closedhand;                       \
+	  ln   -sf   all-scroll            fleur;                            \
+	  ln   -sf   all-scroll            size_all;                         \
+	  ln   -sf   hand1                 grab;                             \
+	  ln   -sf   hand2                 9d800788f1b08800ae810202380a0822; \
+	  ln   -sf   hand2                 e29285e634086352946a0e7090d73106; \
+	  ln   -sf   hand2                 hand;                             \
+	  ln   -sf   hand2                 pointer;                          \
+	  ln   -sf   hand2                 pointing_hand;                    \
+	  ln   -sf   left_ptr              arrow;                            \
+	  ln   -sf   left_ptr              default;                          \
+	  ln   -sf   left_ptr              openhand;                         \
+	  ln   -sf   left_ptr              top_left_arrow;                   \
+	  ln   -sf   left_ptr_watch        08e8e1c95fe2fc01f976f1e063a24ccd; \
+	  ln   -sf   left_ptr_watch        3ecb610c1bf2410f44200f48c40d3599; \
+	  ln   -sf   left_ptr_watch        progress;                         \
+	  ln   -sf   left_side             w-resize;                         \
+	  ln   -sf   link                  3085a0e285430894940527032f8b26df; \
+	  ln   -sf   link                  640fb0e74195791501fd1ed57b41487f; \
+	  ln   -sf   move                  4498f0e0c1937ffe01fd06f973665830; \
+	  ln   -sf   move                  9081237383d90e509aa00f00170e968f; \
+	  ln   -sf   question_arrow        5c6cd98b3f3ebcb1f9c7f1c204630408; \
+	  ln   -sf   question_arrow        d9ce0ab605698f320427677b458ad60b; \
+	  ln   -sf   question_arrow        help;                             \
+	  ln   -sf   question_arrow        left_ptr_help;                    \
+	  ln   -sf   question_arrow        whats_this;                       \
+	  ln   -sf   right_ptr             draft_large;                      \
+	  ln   -sf   right_ptr             draft_small;                      \
+	  ln   -sf   right_side            e-resize;                         \
+	  ln   -sf   sb_h_double_arrow     028006030e0e7ebffc7f7070c0600140; \
+	  ln   -sf   sb_h_double_arrow     14fef782d02440884392942c11205230; \
+	  ln   -sf   sb_h_double_arrow     col-resize;                       \
+	  ln   -sf   sb_h_double_arrow     ew-resize;                        \
+	  ln   -sf   sb_h_double_arrow     h_double_arrow;                   \
+	  ln   -sf   sb_h_double_arrow     size_hor;                         \
+	  ln   -sf   sb_h_double_arrow     split_h;                          \
+	  ln   -sf   sb_up_arrow           up_arrow;                         \
+	  ln   -sf   sb_v_double_arrow     00008160000006810000408080010102; \
+	  ln   -sf   sb_v_double_arrow     2870a09082c103050810ffdffffe0204; \
+	  ln   -sf   sb_v_double_arrow     double_arrow;                     \
+	  ln   -sf   sb_v_double_arrow     ns-resize;                        \
+	  ln   -sf   sb_v_double_arrow     row-resize;                       \
+	  ln   -sf   sb_v_double_arrow     size_ver;                         \
+	  ln   -sf   sb_v_double_arrow     split_v;                          \
+	  ln   -sf   sb_v_double_arrow     v_double_arrow;                   \
+	  ln   -sf   top_left_corner       nw-resize;                        \
+	  ln   -sf   top_right_corner      ne-resize;                        \
+	  ln   -sf   top_side              n-resize;                         \
+	  ln   -sf   watch                 wait;                             \
+	  ln   -sf   X_cursor              pirate;                           \
+	  ln   -sf   xterm                 ibeam;                            \
+	  ln   -sf   xterm                 text;                             \
+	  cd -;                                                              \
+	done
 
 png: adwaita.svg
 	./renderpng.py $^ $(SIZES)
 
+png_hl: png genin.py genhighlight.py
+	./genin.py $(SIZES)
+	./genhighlight.py $(addsuffix .in,$(CURSORS))
+
 tarball:
 	rm -f ../adwaita-cursors.tar.gz
 	tar --exclude='.git*' -cvzf ../adwaita-cursors.tar.gz ../$(notdir $(CURDIR))
+
 clean:
 	rm -f *.in
 	rm -rf Adwaita/cursors
+	rm -rf Adwaita-highlight/cursors
 
 distclean: clean
 	rm -rf png
+	rm -rf png_hl
 
 .PHONY: clean distclean tarball
 .ONESHELL:

--- a/Makefile
+++ b/Makefile
@@ -1,65 +1,21 @@
 SIZES ?= 24 30 36 42 48 54 60 66 72 78 84 90 96
 
+CURSORS = all-scroll bd_double_arrow bottom_left_corner bottom_right_corner \
+bottom_side bottom_tee circle context-menu copy crossed_circle crosshair \
+cross dnd-ask dnd-copy dnd-link dnd-move dnd-no-drop dnd-none dotbox \
+fd_double_arrow grabbing hand1 hand2 left_ptr left_ptr_watch left_side \
+left_tee link ll_angle lr_angle move pencil plus pointer-move question_arrow \
+right_ptr right_side right_tee sb_down_arrow sb_h_double_arrow sb_left_arrow \
+sb_right_arrow sb_up_arrow sb_v_double_arrow tcross top_left_corner \
+top_right_corner top_side top_tee ul_angle ur_angle vertical-text watch \
+X_cursor xterm zoom-in zoom-out
+
 all: png
 	./genin.py $(SIZES)
 	mkdir -p Adwaita/cursors
-	xcursorgen   all-scroll.in            Adwaita/cursors/all-scroll
-	xcursorgen   bd_double_arrow.in       Adwaita/cursors/bd_double_arrow
-	xcursorgen   bottom_left_corner.in    Adwaita/cursors/bottom_left_corner
-	xcursorgen   bottom_right_corner.in   Adwaita/cursors/bottom_right_corner
-	xcursorgen   bottom_side.in           Adwaita/cursors/bottom_side
-	xcursorgen   bottom_tee.in            Adwaita/cursors/bottom_tee
-	xcursorgen   circle.in                Adwaita/cursors/circle
-	xcursorgen   context-menu.in          Adwaita/cursors/context-menu
-	xcursorgen   copy.in                  Adwaita/cursors/copy
-	xcursorgen   crossed_circle.in        Adwaita/cursors/crossed_circle
-	xcursorgen   crosshair.in             Adwaita/cursors/crosshair
-	xcursorgen   cross.in                 Adwaita/cursors/cross
-	xcursorgen   dnd-ask.in               Adwaita/cursors/dnd-ask
-	xcursorgen   dnd-copy.in              Adwaita/cursors/dnd-copy
-	xcursorgen   dnd-link.in              Adwaita/cursors/dnd-link
-	xcursorgen   dnd-move.in              Adwaita/cursors/dnd-move
-	xcursorgen   dnd-no-drop.in           Adwaita/cursors/dnd-no-drop
-	xcursorgen   dnd-none.in              Adwaita/cursors/dnd-none
-	xcursorgen   dotbox.in                Adwaita/cursors/dotbox
-	xcursorgen   fd_double_arrow.in       Adwaita/cursors/fd_double_arrow
-	xcursorgen   grabbing.in              Adwaita/cursors/grabbing
-	xcursorgen   hand1.in                 Adwaita/cursors/hand1
-	xcursorgen   hand2.in                 Adwaita/cursors/hand2
-	xcursorgen   left_ptr.in              Adwaita/cursors/left_ptr
-	xcursorgen   left_ptr_watch.in        Adwaita/cursors/left_ptr_watch
-	xcursorgen   left_side.in             Adwaita/cursors/left_side
-	xcursorgen   left_tee.in              Adwaita/cursors/left_tee
-	xcursorgen   link.in                  Adwaita/cursors/link
-	xcursorgen   ll_angle.in              Adwaita/cursors/ll_angle
-	xcursorgen   lr_angle.in              Adwaita/cursors/lr_angle
-	xcursorgen   move.in                  Adwaita/cursors/move
-	xcursorgen   pencil.in                Adwaita/cursors/pencil
-	xcursorgen   plus.in                  Adwaita/cursors/plus
-	xcursorgen   pointer-move.in          Adwaita/cursors/pointer-move
-	xcursorgen   question_arrow.in        Adwaita/cursors/question_arrow
-	xcursorgen   right_ptr.in             Adwaita/cursors/right_ptr
-	xcursorgen   right_side.in            Adwaita/cursors/right_side
-	xcursorgen   right_tee.in             Adwaita/cursors/right_tee
-	xcursorgen   sb_down_arrow.in         Adwaita/cursors/sb_down_arrow
-	xcursorgen   sb_h_double_arrow.in     Adwaita/cursors/sb_h_double_arrow
-	xcursorgen   sb_left_arrow.in         Adwaita/cursors/sb_left_arrow
-	xcursorgen   sb_right_arrow.in        Adwaita/cursors/sb_right_arrow
-	xcursorgen   sb_up_arrow.in           Adwaita/cursors/sb_up_arrow
-	xcursorgen   sb_v_double_arrow.in     Adwaita/cursors/sb_v_double_arrow
-	xcursorgen   tcross.in                Adwaita/cursors/tcross
-	xcursorgen   top_left_corner.in       Adwaita/cursors/top_left_corner
-	xcursorgen   top_right_corner.in      Adwaita/cursors/top_right_corner
-	xcursorgen   top_side.in              Adwaita/cursors/top_side
-	xcursorgen   top_tee.in               Adwaita/cursors/top_tee
-	xcursorgen   ul_angle.in              Adwaita/cursors/ul_angle
-	xcursorgen   ur_angle.in              Adwaita/cursors/ur_angle
-	xcursorgen   vertical-text.in         Adwaita/cursors/vertical-text
-	xcursorgen   watch.in                 Adwaita/cursors/watch
-	xcursorgen   X_cursor.in              Adwaita/cursors/X_cursor
-	xcursorgen   xterm.in                 Adwaita/cursors/xterm
-	xcursorgen   zoom-in.in               Adwaita/cursors/zoom-in
-	xcursorgen   zoom-out.in              Adwaita/cursors/zoom-out
+	for c in $(CURSORS); do \
+	  xcursorgen $${c}.in Adwaita/cursors/$${c}; \
+	done
 
 	# Now make cursor aliases.
 	cd Adwaita/cursors;                                                \
@@ -148,9 +104,8 @@ clean:
 	rm -f *.in
 	rm -rf Adwaita/cursors
 
-distclean:
-	rm -f *.in
-	rm -rf Adwaita/cursors
+distclean: clean
 	rm -rf png
 
 .PHONY: clean distclean tarball
+.ONESHELL:

--- a/genhighlight.py
+++ b/genhighlight.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Written by Ulrich Drepper <drepper@redhat.com>, 2021.
+import sys
+import os
+import pathlib
+# Unfortunately the PNG module is just named 'png' which conflicts with the local directory.
+#sys.path = [d for d in sys.path if d != '']
+import png
+
+# Start configurations
+
+# Which RGBA color to use for highlighting.
+highlight = [255,255,0,128]
+# Radius of the highlight circle as a fraction of the cursor size.
+radius_fraction = 1 / 2
+# Name of the output directory for the rewritten PNG files.
+pngdir = 'png_hl'
+
+# End configurations
+
+# These values describe the image format and are not really configurable.
+pixeldepth = 8
+maxpixel = 2**pixeldepth-1
+pixelsize = 4
+assert len(highlight) == pixelsize
+
+# Check whether the highlight color is valid, adjust from float format if necessary.
+if not all([isinstance(c, int) and c >= 0 and c <= maxpixel for c in highlight]):
+    if all([(isinstance(c, int) or isinstance(c, float)) and c >= 0 and c <= 1.0 for c in highlight]):
+        highlight = [ int(maxpixel * c) for c in highlight ]
+    else:
+        raise Exception('invalid highlight color {}'.format(highlight))
+
+if not pathlib.Path(pngdir).exists():
+    os.mkdir(pngdir)
+
+for _fname in sys.argv[1:]:
+    fname = pathlib.Path(_fname)
+    with open(fname, 'r') as f:
+        outconf = fname.parent / (fname.stem + '_hl' + fname.suffix)
+        with open(outconf, 'w') as conffd:
+            lines = [ l.strip() for l in f.readlines() ]
+            for line in lines:
+                fields = line.split()
+                size = int(fields[0])
+                xhot = int(fields[1])
+                yhot = int(fields[2])
+                fname = fields[3]
+                tmo = None if len(fields) == 4 else fields[4]
+
+                radius = int(size * radius_fraction)
+                radius_sq = int(size**2 * radius_fraction**2)
+
+                path = pathlib.Path(fname)
+                outfname = pathlib.Path(pngdir, *path.parts[1:])
+
+                with open(fname, 'rb') as fpng:
+                    inpng = png.Reader(fpng)
+                    indata = inpng.read()
+
+                    # The size of the original image.
+                    origw = indata[3]['size'][0]
+                    origh = indata[3]['size'][1]
+
+                    # Determine how much space to add on each side for the highlight circle.
+                    addl = max(0, radius-xhot)
+                    addr = max(0, xhot+radius+1-size)
+                    addt = max(0, radius-yhot)
+                    addb = max(0, yhot+radius+1-size)
+
+                    # The size of the new image.
+                    neww = origw + addr + addl
+                    newh = origh + addb + addt
+
+                    if neww == origw and newh == origh:
+                        # The new image has the same size.  Change format to list of lists.
+                        bytes = [ list(row) for row in indata[2] ]
+                    else:
+                        # Construct a new list of list with the pixel values of old image, padded appropriately.
+                        bytes = []
+                        for _ in range(addt):
+                            bytes.append([0]*(neww*pixelsize))
+                        for r in indata[2]:
+                            row = [0]*(addl*pixelsize) + list(r) + [0]*(addr*pixelsize)
+                            bytes.append(row)
+                        for _ in range(addb):
+                            bytes.append([0]*(neww*pixelsize))
+                        assert len(bytes) == newh, '{}: {} instead of {}'.format(fname, len(bytes), newh)
+                        for r in bytes:
+                            assert len(r) == neww*pixelsize, '{}: {} instead of {}'.format(fname, len(r), neww*pixelsize)
+
+                    # Move the hotspot, if necessary.
+                    xhot += addl
+                    yhot += addt
+
+                    # Add in the highlight circle using color blending.
+                    for y in range(yhot-radius, yhot+radius+1):
+                        for x in range(xhot-radius, xhot+radius+1):
+                            ox = xhot - x
+                            oy = yhot - y
+                            # Determine whether this point is at the inside of the circle.
+                            if oy**2+ox**2<=radius_sq:
+                                # Original image color.
+                                curcol = bytes[y][x*pixelsize:(x+1)*pixelsize]
+                                # Porter-Duff blending.
+                                alpha_a = curcol[3] / maxpixel
+                                alpha_b = highlight[3] / maxpixel
+                                fact1 = alpha_a
+                                fact2 = (1 - alpha_a) * alpha_b
+                                alpha_c = fact1 + fact2
+                                # Compute the new color.  Use min in case some rounding error causes problems.
+                                newcol = [ min(maxpixel, int((fact1 * curcol[i] + fact2 * highlight[i]) / alpha_c)) for i in range(3) ] + [ int(alpha_c * maxpixel) ]
+                                bytes[y][x*pixelsize:(x+1)*pixelsize] = newcol
+
+                    if not outfname.parent.exists():
+                        os.mkdir(outfname.parent)
+
+                    with open(outfname, 'wb') as outfd:
+                        outpng = png.Writer(neww, newh, greyscale=False, alpha=True, bitdepth=pixeldepth)
+                        outpng.write(outfd, bytes)
+
+                    if tmo:
+                        conffd.write('{} {} {} {} {}\n'.format(size, xhot, yhot, outfname, tmo))
+                    else:
+                        conffd.write('{} {} {} {}\n'.format(size, xhot, yhot, outfname))


### PR DESCRIPTION
One of the easiest-to-use ways to make the cursor better visible (especially for screen sharing and recording) is to add the highlighting right into the cursor graphics itself. This change adds a script which automatically creates such a new set of cursor files.  The change should be low maintainance because all the needed information is derived from files which are generated. All that was needed were a few changes to the Makefile to avoid duplication.

Packagers would only need to add python3-pypng (for Fedora) as a build dependency.